### PR TITLE
Fix windows path translation problem

### DIFF
--- a/session.js
+++ b/session.js
@@ -356,9 +356,11 @@ module.exports = function (
 	// internal API
 
 	Session.prototype._chroot = function (path) {
-		path = paths.join(this.root.replace('/', paths.sep), path.replace('/', paths.sep)).replace(paths.sep, '/');
+		if (path.charAt(0) !== '/') {
+			path = (this.root + '/' + path).replace(/^\/\//, '/');
+		}
 		if (path.length > 1 && path[path.length - 1] === '/') {
-			path = path.substring(0, path.length - 1)
+			path = path.substring(0, path.length - 1);
 		}
 		return path
 	}

--- a/session.js
+++ b/session.js
@@ -356,7 +356,7 @@ module.exports = function (
 	// internal API
 
 	Session.prototype._chroot = function (path) {
-		path = paths.join(this.root, path)
+		path = paths.join(this.root.replace('/', path.sep), path.replace('/', path.sep)).replace(path.sep, '/');
 		if (path.length > 1 && path[path.length - 1] === '/') {
 			path = path.substring(0, path.length - 1)
 		}

--- a/session.js
+++ b/session.js
@@ -356,7 +356,7 @@ module.exports = function (
 	// internal API
 
 	Session.prototype._chroot = function (path) {
-		path = paths.join(this.root.replace('/', path.sep), path.replace('/', path.sep)).replace(path.sep, '/');
+		path = paths.join(this.root.replace('/', paths.sep), path.replace('/', paths.sep)).replace(paths.sep, '/');
 		if (path.length > 1 && path[path.length - 1] === '/') {
 			path = path.substring(0, path.length - 1)
 		}


### PR DESCRIPTION
When using path.join under windows the system will use backslashes which won't work with zookeeper paths.
