### PR TITLE
implemented rmrf without using async

### DIFF
--- a/session.js
+++ b/session.js
@@ -280,25 +280,26 @@ module.exports = function (
 	}
 
 	Session.prototype.rmrf = function (path, cb) {
-		// this.getChildren(
-		// 	path,
-		// 	function (err, children, stat) {
-		// 		if (err) {
-		// 			return cb(err)
-		// 		}
-		// 		if (children.length === 0) {
-		// 			return this.del(path, stat.version, cb)
-		// 		}
-		// 		async.forEachSeries(
-		// 			children,
-		// 			function (child, next) {
-		// 				this.rmrf(path + '/' + child, next)
-		// 			}.bind(this),
-		// 			cb
-		// 		)
-		// 	}.bind(this)
-		// )
-		assert(false, 'Not Implemented')
+		var self = this;
+		this.getChildren(
+		path,
+		function (err, children, stat) {
+			if (err) {
+				return cb(err);
+			}
+			function deleteOne(err) {
+				if (err) {
+					return cb(err);
+				}
+				var child = children.splice(0, 1)[0];
+				if (child) {
+					self.rmrf(path + '/' + child, deleteOne);
+				} else {
+					self.del(path, stat.version, cb);
+				}
+			}
+			deleteOne();
+		});
 	}
 
 	Session.prototype.set = function (path, data, version, cb) {


### PR DESCRIPTION
The rmrf function wasn't implemented, or rather it was and was commented out presumably because the initial implementation used the async module and it was decided not to pull that module into the project. This change does a recursive delete of ZK nodes without using that module.
